### PR TITLE
Follow other test format for get_caller_identity to make this pass

### DIFF
--- a/test/lib/sts_test.exs
+++ b/test/lib/sts_test.exs
@@ -2,10 +2,15 @@ defmodule ExAws.STSTest do
   use ExUnit.Case, async: true
   alias ExAws.STS
 
-  test "basic actual hit on the service" do
-    result = ExAws.STS.get_caller_identity() |> ExAws.request()
+  test "#get_caller_identity" do
+    version = "2011-06-15"
 
-    assert {:ok, %{body: %{account: _}}} = result
+    expected = %{
+      "Action" => "GetCallerIdentity",
+      "Version" => version
+    }
+
+    assert expected == STS.get_caller_identity().params
   end
 
   test "#assume_role" do


### PR DESCRIPTION
The get_caller_identity test was not passing as this made a call to AWS. If this is an integration test, then we would either make this clearer and add documentation how this test can pass when developing with this package.

I have made the test follow the same format as the other tests to make the test pass. This tests the params of the query it will call.

We could look at mocking the request response, to make the test pass without setup, but that seemed a step too far for now.

Thoughts and ideas on this suggestion are appreciated.