### PR TITLE
Add GetAccessKeyInfo

### DIFF
--- a/lib/ex_aws/sts.ex
+++ b/lib/ex_aws/sts.ex
@@ -36,6 +36,12 @@ defmodule ExAws.STS do
     })
   end
 
+  @doc "Get Access Key Info"
+  @spec get_access_key_info(key_id :: String.t()) :: ExAws.Operation.Query.t()
+  def get_access_key_info(key_id) do
+    request(:get_access_key_info, %{"AccessKeyId" => key_id})
+  end
+
   @doc "Get Caller Identity"
   def get_caller_identity() do
     request(:get_caller_identity, %{})

--- a/lib/ex_aws/sts/parsers.ex
+++ b/lib/ex_aws/sts/parsers.ex
@@ -18,6 +18,16 @@ if Code.ensure_loaded?(SweetXml) do
       {:ok, Map.put(resp, :body, parsed_body)}
     end
 
+    def parse({:ok, %{body: xml} = resp}, :get_access_key_info) do
+      parsed_body =
+        SweetXml.xpath(xml, ~x"//GetAccessKeyInfoResponse",
+          account: ~x"./GetAccessKeyInfoResult/Account/text()"s,
+          request_id: request_id_xpath()
+        )
+
+      {:ok, Map.put(resp, :body, parsed_body)}
+    end
+
     def parse({:ok, %{body: xml} = resp}, :get_caller_identity) do
       parsed_body =
         SweetXml.xpath(xml, ~x"//GetCallerIdentityResponse",

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }

--- a/test/lib/sts_test.exs
+++ b/test/lib/sts_test.exs
@@ -36,6 +36,19 @@ defmodule ExAws.STSTest do
     assert expected == STS.decode_authorization_message(message).params
   end
 
+  test "#get_access_key_info" do
+    version = "2011-06-15"
+    key_id = "AKIAI44QH8DHBEXAMPLE"
+
+    expected = %{
+      "Action" => "GetAccessKeyInfo",
+      "AccessKeyId" => key_id,
+      "Version" => version
+    }
+
+    assert expected == STS.get_access_key_info(key_id).params
+  end
+
   test "#get_federation_token" do
     version = "2011-06-15"
     duration = 900


### PR DESCRIPTION
This adds support for `GetAccessKeyInfo` according to AWS Documentation at: https://docs.aws.amazon.com/STS/latest/APIReference/API_GetAccessKeyInfo.html