### PR TITLE
Correctly add external_id to request params

### DIFF
--- a/lib/ex_aws/sts.ex
+++ b/lib/ex_aws/sts.ex
@@ -96,5 +96,6 @@ defmodule ExAws.STS do
   defp parse_opt(opts, {:duration, val}), do: Map.put(opts, "DurationSeconds", val)
   defp parse_opt(opts, {:token_code, val}), do: Map.put(opts, "TokenCode", val)
   defp parse_opt(opts, {:serial_number, val}), do: Map.put(opts, "SerialNumber", val)
+  defp parse_opt(opts, {:external_id, val}), do: Map.put(opts, "ExternalId", val)
   defp parse_opt(opts, {:policy, val}), do: Map.put(opts, "Policy", Poison.encode!(val))
 end

--- a/mix.lock
+++ b/mix.lock
@@ -12,7 +12,7 @@
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
This correctly adds the already defined optional parameter `external_id` to the request params as `ExternalId` for `assume_role`.