### PR TITLE
Increment patch for publish to hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAws.STS.Mixfile do
   use Mix.Project
 
-  @version "2.0.1"
+  @version "2.0.2"
   @service "sts"
   @url "https://github.com/ex-aws/ex_aws_#{@service}"
   @name __MODULE__ |> Module.split() |> Enum.take(2) |> Enum.join(".")

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule ExAws.STS.Mixfile do
   use Mix.Project
 
-  @version "2.0.2"
+  @version "2.1.0"
   @service "sts"
   @url "https://github.com/ex-aws/ex_aws_#{@service}"
   @name __MODULE__ |> Module.split() |> Enum.take(2) |> Enum.join(".")


### PR DESCRIPTION
Following the instructions [here](https://hex.pm/docs/publish).

With this change I should be able to run `mix hex.publish` to publish a new version.

@vanetix 