### PR TITLE
Allow STS credentials to be injected by configuration

### DIFF
--- a/lib/ex_aws/sts/auth_cache/assume_role_credentials_adapter.ex
+++ b/lib/ex_aws/sts/auth_cache/assume_role_credentials_adapter.ex
@@ -57,7 +57,5 @@ defmodule ExAws.STS.AuthCache.AssumeRoleCredentialsAdapter do
     Enum.max([Enum.min([max, seconds]), min])
   end
 
-  defp load_credentials(profile) do
-    ExAws.CredentialsIni.security_credentials(profile)
-  end
+  defp load_credentials(profile), do: ExAws.Config.awscli_auth_credentials(profile)
 end


### PR DESCRIPTION
## Problem
In order to make `ex_aws` fully production-ready, we need to take into account the containerized applications that run, for example, over Kubernetes or Nomad. A typical configuration of secrets for this kind of application is by injection using environment variables. It is very common to restrict write permissions on the file system to avoid security problems also.

The aforementioned facts enter in conflict with the design of the STS module which resides on a file system file in order to assume a role for example.

## Proposed solution
Use the new way of fetching the credentials without coupling the retrieval to a file in the filesystem. Follow the upstream PR to understand the changes: 
https://github.com/ex-aws/ex_aws/pull/747