### PR TITLE
Remove hardcoded poison call 

### DIFF
--- a/lib/ex_aws/sts.ex
+++ b/lib/ex_aws/sts.ex
@@ -148,5 +148,7 @@ defmodule ExAws.STS do
   defp parse_opt(opts, {:serial_number, val}), do: Map.put(opts, "SerialNumber", val)
   defp parse_opt(opts, {:provider_id, val}), do: Map.put(opts, "ProviderId", val)
   defp parse_opt(opts, {:external_id, val}), do: Map.put(opts, "ExternalId", val)
-  defp parse_opt(opts, {:policy, val}), do: Map.put(opts, "Policy", Poison.encode!(val))
+  defp parse_opt(opts, {:policy, val}), do: Map.put(opts, "Policy", json_codec().encode!(val))
+
+  defp json_codec(), do: ExAws.Config.build_base(:sts) |> Map.get(:json_codec)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule ExAws.STS.Mixfile do
       {:briefly, ">= 0.0.3", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:hackney, ">= 0.0.0", only: [:dev, :test]},
-      {:sweet_xml, ">= 0.0.0", only: [:dev]},
+      {:sweet_xml, ">= 0.0.0", only: [:dev, :test]},
       {:poison, ">= 0.0.0", only: [:dev, :test]},
       ex_aws()
     ]

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -10,6 +10,7 @@ defmodule ExAws.STS.ParsersTest do
     case arity do
       2 ->
         Parsers.parse(mock_response, action)
+
       3 ->
         config = [json_codec: Poison]
 


### PR DESCRIPTION
Replaces hardcoded `Poison` call with the configured ExAws json library.

Closes #20.