### PR TITLE
Allow security_token to be set by AssumeRoleWebIdentityAdapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Similarly, it is possible to use a web identity token to perform the assume role
 config :ex_aws,
   secret_access_key: [{:awscli, "profile_name", 30}],
   access_key_id: [{:awscli, "profile_name", 30}],
+  security_token: [{:awscli, "profile_name", 30}],
   awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
 ```
 

--- a/lib/ex_aws/sts/auth_cache/assume_role_web_identity_adapter.ex
+++ b/lib/ex_aws/sts/auth_cache/assume_role_web_identity_adapter.ex
@@ -56,10 +56,11 @@ defmodule ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter do
       role_arn: env_role_arn(config),
       role_session_name: role_session_name(config),
       web_identity_token: web_identity_token(config),
-      # necessary for now due to how ExAws.request() works
+      # Prevent recursive callback from ExAws.request()
+      # by overriding configs that use :awscli
       access_key_id: "dummy",
-      # necessary for now due to how ExAws.request() works
-      secret_access_key: "dummy"
+      secret_access_key: "dummy",
+      security_token: "dummy"
     }
   end
 

--- a/test/lib/auth_cache/assume_role_web_identity_adapter_test.exs
+++ b/test/lib/auth_cache/assume_role_web_identity_adapter_test.exs
@@ -32,6 +32,7 @@ defmodule ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapterTest do
         role_session_name: "test",
         access_key_id: "dummy",
         secret_access_key: "dummy",
+        security_token: "dummy",
         http_client: ExAws.Request.HttpMock
       }
 


### PR DESCRIPTION
AWS needs a "security_token" in the request when using AssumeRoleWebIdentity on EKS.
But if we try to set it using ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter, there is a recursive loop from AssumeRoleWebIdentityAdapter to ExAws.request() and back to itself.

By using the same technique used for access_key_id and secret_access_key, i.e. set those config value to a dummy string, we can prevent the recursive callback and have a security_token set by the adapter.

I did try running tests but some of them were failing without my change.