### PR TITLE
fix: update the failing config example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,13 @@ Similarly, it is possible to use a web identity token to perform the assume role
 config :ex_aws,
   secret_access_key: [{:awscli, "profile_name", 30}],
   access_key_id: [{:awscli, "profile_name", 30}],
-  awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
+  awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter,
+  awscli_credentials: %{
+    "profile_name" => %{
+      role_arn: System.get_env("AWS_ROLE_ARN"),
+      source_profile: "profile_name"
+    }
+  }
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ config :ex_aws,
   awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleCredentialsAdapter,
   awscli_credentials: %{
     "default" => %{
-      role_arn: {:system, "AWS_ROLE_ARN"},
-      access_key_id: {:system, "AWS_ACCESS_KEY_ID"},
-      secret_access_key: {:system, "AWS_SECRET_ACCESS_KEY"},
+      role_arn: System.get_env("AWS_ROLE_ARN"),
+      access_key_id: System.get_env("AWS_ACCESS_KEY_ID"),
+      secret_access_key: System.get_env("AWS_SECRET_ACCESS_KEY"),
       source_profile: "default"
     }
   }


### PR DESCRIPTION
- If the config is taken as is from the README, it fails with the following error: 
```
        ** (Protocol.UndefinedError) protocol String.Chars not implemented for {:system, "AWS_ROLE_ARN"} of type Tuple. This protocol is implemented for the following type(s): Atom, BitString, CloudfrontSigner.Policy, Date, DateTime, Decimal, Float, Hex.Solver.Assignment, Hex.Solver.Constraints.Empty, Hex.Solver.Constraints.Range, Hex.Solver.Constraints.Union, Hex.Solver.Incompatibility, Hex.Solver.PackageRange, Hex.Solver.Term, Integer, List, NaiveDateTime, Phoenix.LiveComponent.CID, Postgrex.Copy, Postgrex.Query, Time, URI, Version, Version.Requirement
            (elixir 1.14.1) lib/string/chars.ex:3: String.Chars.impl_for!/1
            (elixir 1.14.1) lib/string/chars.ex:22: String.Chars.to_string/1
            (elixir 1.14.1) lib/uri.ex:153: URI.encode_kv_pair/2
            (elixir 1.14.1) lib/enum.ex:1755: anonymous fn/2 in Enum.map_join/3
            (elixir 1.14.1) lib/enum.ex:1725: anonymous fn/4 in Enum.map_intersperse/3
            (stdlib 4.1) maps.erl:411: :maps.fold_1/3
            (elixir 1.14.1) lib/enum.ex:2480: Enum.map_intersperse/3
            (elixir 1.14.1) lib/enum.ex:1755: Enum.map_join/3
```


This PR updates the example so that it will work correctly without error.