### PR TITLE
Improve docs about :awscli credentials expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.3.0 - 2020-05-15
 
-- Removed hardcoded `Poison` dependency, now uses configured `json_codec` within thP parent `ex_aws` module.
+- Removed hardcoded `Poison` dependency, now uses configured `json_codec` within the parent `ex_aws` module.
 
 ## v2.2.0 - 2020-05-14
 

--- a/README.md
+++ b/README.md
@@ -40,14 +40,16 @@ When specified in your `~/.aws/config` you can set
  
 ```elixir
 config :ex_aws,
-  secret_access_key: [{:awscli, "profile_name", 30}],
-  access_key_id: [{:awscli, "profile_name", 30}],
+  secret_access_key: [{:awscli, "profile_name", 1_800}],
+  access_key_id: [{:awscli, "profile_name", 1_800}],
   awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleCredentialsAdapter
 ```
 
 and if the profile `profile_name` sets a `role_arn` then this will make ExAws
 issue an `AssumeRoleCredentials` request to fetch the `access_key_id`
 and `secret_access_key`.
+The third element in the tuple (1_800 in the example) is the desired expiration in seconds.
+[AWS enforces a minimum](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#API_AssumeRole_RequestParameters) of 900 seconds (15 minutes).
 
 ### Using AWS CLI config from ENV vars
 
@@ -57,8 +59,8 @@ In order to do that, just place in the config the block `awscli_credentials` wit
 
 ```elixir
 config :ex_aws,
-  access_key_id: [{:awscli, "default", 30}],
-  secret_access_key: [{:awscli, "default", 30}],
+  access_key_id: [{:awscli, "default", 1_800}],
+  secret_access_key: [{:awscli, "default", 1_800}],
   awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleCredentialsAdapter,
   awscli_credentials: %{
     "default" => %{
@@ -79,8 +81,8 @@ Similarly, it is possible to use a web identity token to perform the assume role
 
 ```elixir
 config :ex_aws,
-  secret_access_key: [{:awscli, "profile_name", 30}],
-  access_key_id: [{:awscli, "profile_name", 30}],
+  secret_access_key: [{:awscli, "profile_name", 1_800}],
+  access_key_id: [{:awscli, "profile_name", 1_800}],
   awscli_auth_adapter: ExAws.STS.AuthCache.AssumeRoleWebIdentityAdapter
 ```
 


### PR DESCRIPTION
I can't find any docs for the third element in the config tuple. From my understanding of the code, it is the expiration in seconds.

The examples in the readme are `30`, which some people might assume are in minutes. If we use a higher value it will reduce the risk of this misunderstanding.