### PR TITLE
Raise when `sweet_xml` dependency is missing while using role based authentication

### DIFF
--- a/lib/ex_aws/sts/parsers.ex
+++ b/lib/ex_aws/sts/parsers.ex
@@ -1,160 +1,137 @@
-if Code.ensure_loaded?(SweetXml) do
-  defmodule ExAws.STS.Parsers do
-    import SweetXml, only: [sigil_x: 2]
+defmodule ExAws.STS.Parsers do
+  alias ExAws.STS.Parsers.XML
 
-    def parse({:ok, %{body: xml} = resp}, :assume_role) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//AssumeRoleResponse",
-          access_key_id: ~x"./AssumeRoleResult/Credentials/AccessKeyId/text()"s,
-          secret_access_key: ~x"./AssumeRoleResult/Credentials/SecretAccessKey/text()"s,
-          session_token: ~x"./AssumeRoleResult/Credentials/SessionToken/text()"s,
-          expiration: ~x"./AssumeRoleResult/Credentials/Expiration/text()"s,
-          assumed_role_id: ~x"./AssumeRoleResult/AssumedRoleUser/AssumedRoleId/text()"s,
-          assumed_role_arn: ~x"./AssumeRoleResult/AssumedRoleUser/Arn/text()"s,
-          request_id: request_id_xpath()
-        )
+  import XML, only: [sigil_x: 2]
 
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
+  def parse({:ok, %{body: xml} = resp}, :assume_role) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//AssumeRoleResponse",
+        access_key_id: ~x"./AssumeRoleResult/Credentials/AccessKeyId/text()"s,
+        secret_access_key: ~x"./AssumeRoleResult/Credentials/SecretAccessKey/text()"s,
+        session_token: ~x"./AssumeRoleResult/Credentials/SessionToken/text()"s,
+        expiration: ~x"./AssumeRoleResult/Credentials/Expiration/text()"s,
+        assumed_role_id: ~x"./AssumeRoleResult/AssumedRoleUser/AssumedRoleId/text()"s,
+        assumed_role_arn: ~x"./AssumeRoleResult/AssumedRoleUser/Arn/text()"s,
+        request_id: request_id_xpath()
+      )
 
-    def parse({:ok, %{body: xml} = resp}, :assume_role_with_web_identity) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//AssumeRoleWithWebIdentityResponse",
-          access_key_id: ~x"./AssumeRoleWithWebIdentityResult/Credentials/AccessKeyId/text()"s,
-          secret_access_key:
-            ~x"./AssumeRoleWithWebIdentityResult/Credentials/SecretAccessKey/text()"s,
-          session_token: ~x"./AssumeRoleWithWebIdentityResult/Credentials/SessionToken/text()"s,
-          expiration: ~x"./AssumeRoleWithWebIdentityResult/Credentials/Expiration/text()"s,
-          assumed_role_id:
-            ~x"./AssumeRoleWithWebIdentityResult/AssumedRoleUser/AssumedRoleId/text()"s,
-          assumed_role_arn: ~x"./AssumeRoleWithWebIdentityResult/AssumedRoleUser/Arn/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:ok, %{body: xml} = resp}, :get_access_key_info) do
-      parsed_body =
-        SweetXml.xpath(xml, ~x"//GetAccessKeyInfoResponse",
-          account: ~x"./GetAccessKeyInfoResult/Account/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:ok, %{body: xml} = resp}, :assume_role_with_s_a_m_l) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//AssumeRoleWithSAMLResponse",
-          access_key_id: ~x"./AssumeRoleResult/Credentials/AccessKeyId/text()"s,
-          secret_access_key: ~x"./AssumeRoleResult/Credentials/SecretAccessKey/text()"s,
-          session_token: ~x"./AssumeRoleResult/Credentials/SessionToken/text()"s,
-          expiration: ~x"./AssumeRoleResult/Credentials/Expiration/text()"s,
-          assumed_role_id: ~x"./AssumeRoleResult/AssumedRoleUser/AssumedRoleId/text()"s,
-          assumed_role_arn: ~x"./AssumeRoleResult/AssumedRoleUser/Arn/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:ok, %{body: xml} = resp}, :get_caller_identity) do
-      parsed_body =
-        SweetXml.xpath(xml, ~x"//GetCallerIdentityResponse",
-          arn: ~x"./GetCallerIdentityResult/Arn/text()"s,
-          user_id: ~x"./GetCallerIdentityResult/UserId/text()"s,
-          account: ~x"./GetCallerIdentityResult/Account/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:ok, %{body: xml} = resp}, :get_federation_token) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//GetFederationTokenResponse",
-          access_key_id: ~x"./GetFederationTokenResult/Credentials/AccessKeyId/text()"s,
-          secret_access_key: ~x"./GetFederationTokenResult/Credentials/SecretAccessKey/text()"s,
-          session_token: ~x"./GetFederationTokenResult/Credentials/SessionToken/text()"s,
-          expiration: ~x"./GetFederationTokenResult/Credentials/Expiration/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:ok, %{body: xml} = resp}, :get_session_token) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//GetSessionTokenResponse",
-          access_key_id: ~x"./GetSessionTokenResult/Credentials/AccessKeyId/text()"s,
-          secret_access_key: ~x"./GetSessionTokenResult/Credentials/SecretAccessKey/text()"s,
-          session_token: ~x"./GetSessionTokenResult/Credentials/SessionToken/text()"s,
-          expiration: ~x"./GetSessionTokenResult/Credentials/Expiration/text()"s,
-          request_id: request_id_xpath()
-        )
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    def parse({:error, {type, http_status_code, %{body: xml}}}, _) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//ErrorResponse",
-          request_id: ~x"./RequestId/text()"s,
-          type: ~x"./Error/Type/text()"s,
-          code: ~x"./Error/Code/text()"s,
-          message: ~x"./Error/Message/text()"s,
-          detail: ~x"./Error/Detail/text()"s
-        )
-
-      {:error, {type, http_status_code, parsed_body}}
-    end
-
-    def parse(val, _), do: val
-
-    def parse({:ok, %{body: xml} = resp}, :decode_authorization_message, config) do
-      parsed_body =
-        xml
-        |> SweetXml.xpath(~x"//DecodeAuthorizationMessageResponse",
-          decoded_message: ~x"./DecodedMessage/text()"s,
-          request_id: ~x"./RequestId/text()"s
-        )
-        |> Map.update!(:decoded_message, fn msg -> config[:json_codec].decode!(msg) end)
-
-      {:ok, Map.put(resp, :body, parsed_body)}
-    end
-
-    defp request_id_xpath do
-      ~x"./ResponseMetadata/RequestId/text()"s
-    end
+    {:ok, Map.put(resp, :body, parsed_body)}
   end
-else
-  defmodule ExAws.STS.Parsers do
-    def parse({:ok, %{body: _xml} = _resp}, :assume_role), do: missing_sweetxml()
 
-    def parse({:ok, %{body: _xml} = _resp}, :assume_role_with_web_identity),
-      do: missing_sweetxml()
+  def parse({:ok, %{body: xml} = resp}, :assume_role_with_web_identity) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//AssumeRoleWithWebIdentityResponse",
+        access_key_id: ~x"./AssumeRoleWithWebIdentityResult/Credentials/AccessKeyId/text()"s,
+        secret_access_key:
+          ~x"./AssumeRoleWithWebIdentityResult/Credentials/SecretAccessKey/text()"s,
+        session_token: ~x"./AssumeRoleWithWebIdentityResult/Credentials/SessionToken/text()"s,
+        expiration: ~x"./AssumeRoleWithWebIdentityResult/Credentials/Expiration/text()"s,
+        assumed_role_id:
+          ~x"./AssumeRoleWithWebIdentityResult/AssumedRoleUser/AssumedRoleId/text()"s,
+        assumed_role_arn: ~x"./AssumeRoleWithWebIdentityResult/AssumedRoleUser/Arn/text()"s,
+        request_id: request_id_xpath()
+      )
 
-    def parse({:ok, %{body: _xml} = _resp}, :get_access_key_info), do: missing_sweetxml()
-    def parse({:ok, %{body: _xml} = _resp}, :assume_role_with_s_a_m_l), do: missing_sweetxml()
-    def parse({:ok, %{body: _xml} = _resp}, :get_caller_identity), do: missing_sweetxml()
-    def parse({:ok, %{body: _xml} = _resp}, :get_federation_token), do: missing_sweetxml()
-    def parse({:ok, %{body: _xml} = _resp}, :get_session_token), do: missing_sweetxml()
-    def parse({:error, {_type, _http_status_code, %{body: _xml}}}, _), do: missing_sweetxml()
-    def parse(val, _), do: val
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
 
-    def parse({:ok, %{body: _xml} = _resp}, :decode_authorization_message, _config),
-      do: missing_sweetxml()
+  def parse({:ok, %{body: xml} = resp}, :get_access_key_info) do
+    parsed_body =
+      XML.xpath(xml, ~x"//GetAccessKeyInfoResponse",
+        account: ~x"./GetAccessKeyInfoResult/Account/text()"s,
+        request_id: request_id_xpath()
+      )
 
-    def parse(val, _, _), do: val
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
 
-    defp missing_sweetxml,
-      do: raise("Dependency sweet_xml is required for role based authentication")
+  def parse({:ok, %{body: xml} = resp}, :assume_role_with_s_a_m_l) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//AssumeRoleWithSAMLResponse",
+        access_key_id: ~x"./AssumeRoleResult/Credentials/AccessKeyId/text()"s,
+        secret_access_key: ~x"./AssumeRoleResult/Credentials/SecretAccessKey/text()"s,
+        session_token: ~x"./AssumeRoleResult/Credentials/SessionToken/text()"s,
+        expiration: ~x"./AssumeRoleResult/Credentials/Expiration/text()"s,
+        assumed_role_id: ~x"./AssumeRoleResult/AssumedRoleUser/AssumedRoleId/text()"s,
+        assumed_role_arn: ~x"./AssumeRoleResult/AssumedRoleUser/Arn/text()"s,
+        request_id: request_id_xpath()
+      )
+
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
+
+  def parse({:ok, %{body: xml} = resp}, :get_caller_identity) do
+    parsed_body =
+      XML.xpath(xml, ~x"//GetCallerIdentityResponse",
+        arn: ~x"./GetCallerIdentityResult/Arn/text()"s,
+        user_id: ~x"./GetCallerIdentityResult/UserId/text()"s,
+        account: ~x"./GetCallerIdentityResult/Account/text()"s,
+        request_id: request_id_xpath()
+      )
+
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
+
+  def parse({:ok, %{body: xml} = resp}, :get_federation_token) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//GetFederationTokenResponse",
+        access_key_id: ~x"./GetFederationTokenResult/Credentials/AccessKeyId/text()"s,
+        secret_access_key: ~x"./GetFederationTokenResult/Credentials/SecretAccessKey/text()"s,
+        session_token: ~x"./GetFederationTokenResult/Credentials/SessionToken/text()"s,
+        expiration: ~x"./GetFederationTokenResult/Credentials/Expiration/text()"s,
+        request_id: request_id_xpath()
+      )
+
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
+
+  def parse({:ok, %{body: xml} = resp}, :get_session_token) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//GetSessionTokenResponse",
+        access_key_id: ~x"./GetSessionTokenResult/Credentials/AccessKeyId/text()"s,
+        secret_access_key: ~x"./GetSessionTokenResult/Credentials/SecretAccessKey/text()"s,
+        session_token: ~x"./GetSessionTokenResult/Credentials/SessionToken/text()"s,
+        expiration: ~x"./GetSessionTokenResult/Credentials/Expiration/text()"s,
+        request_id: request_id_xpath()
+      )
+
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
+
+  def parse({:error, {type, http_status_code, %{body: xml}}}, _) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//ErrorResponse",
+        request_id: ~x"./RequestId/text()"s,
+        type: ~x"./Error/Type/text()"s,
+        code: ~x"./Error/Code/text()"s,
+        message: ~x"./Error/Message/text()"s,
+        detail: ~x"./Error/Detail/text()"s
+      )
+
+    {:error, {type, http_status_code, parsed_body}}
+  end
+
+  def parse(val, _), do: val
+
+  def parse({:ok, %{body: xml} = resp}, :decode_authorization_message, config) do
+    parsed_body =
+      xml
+      |> XML.xpath(~x"//DecodeAuthorizationMessageResponse",
+        decoded_message: ~x"./DecodedMessage/text()"s,
+        request_id: ~x"./RequestId/text()"s
+      )
+      |> Map.update!(:decoded_message, fn msg -> config[:json_codec].decode!(msg) end)
+
+    {:ok, Map.put(resp, :body, parsed_body)}
+  end
+
+  defp request_id_xpath do
+    ~x"./ResponseMetadata/RequestId/text()"s
   end
 end

--- a/lib/ex_aws/sts/parsers.ex
+++ b/lib/ex_aws/sts/parsers.ex
@@ -136,7 +136,25 @@ if Code.ensure_loaded?(SweetXml) do
   end
 else
   defmodule ExAws.STS.Parsers do
+    def parse({:ok, %{body: _xml} = _resp}, :assume_role), do: missing_sweetxml()
+
+    def parse({:ok, %{body: _xml} = _resp}, :assume_role_with_web_identity),
+      do: missing_sweetxml()
+
+    def parse({:ok, %{body: _xml} = _resp}, :get_access_key_info), do: missing_sweetxml()
+    def parse({:ok, %{body: _xml} = _resp}, :assume_role_with_s_a_m_l), do: missing_sweetxml()
+    def parse({:ok, %{body: _xml} = _resp}, :get_caller_identity), do: missing_sweetxml()
+    def parse({:ok, %{body: _xml} = _resp}, :get_federation_token), do: missing_sweetxml()
+    def parse({:ok, %{body: _xml} = _resp}, :get_session_token), do: missing_sweetxml()
+    def parse({:error, {_type, _http_status_code, %{body: _xml}}}, _), do: missing_sweetxml()
     def parse(val, _), do: val
+
+    def parse({:ok, %{body: _xml} = _resp}, :decode_authorization_message, _config),
+      do: missing_sweetxml()
+
     def parse(val, _, _), do: val
+
+    defp missing_sweetxml,
+      do: raise("Dependency sweet_xml is required for role based authentication")
   end
 end

--- a/lib/ex_aws/sts/parsers/xml.ex
+++ b/lib/ex_aws/sts/parsers/xml.ex
@@ -1,0 +1,14 @@
+defmodule ExAws.STS.Parsers.XML do
+  @moduledoc false
+
+  if Code.ensure_loaded?(SweetXml) do
+    defdelegate xpath(parent, spec, subspec), to: SweetXml
+    defdelegate sigil_x(path, modifiers), to: SweetXml
+  else
+    def xpath(_parent, _spec, _subspec),
+      do: raise("Dependency sweet_xml is required for role based authentication")
+
+    def sigil_x(_path, _modifiers),
+      do: raise("Dependency sweet_xml is required for role based authentication")
+  end
+end

--- a/lib/ex_aws/sts/parsers/xml.ex
+++ b/lib/ex_aws/sts/parsers/xml.ex
@@ -1,14 +1,19 @@
 defmodule ExAws.STS.Parsers.XML do
   @moduledoc false
 
-  if Code.ensure_loaded?(SweetXml) do
-    defdelegate xpath(parent, spec, subspec), to: SweetXml
-    defdelegate sigil_x(path, modifiers), to: SweetXml
-  else
-    def xpath(_parent, _spec, _subspec),
-      do: raise("Dependency sweet_xml is required for role based authentication")
-
-    def sigil_x(_path, _modifiers),
-      do: raise("Dependency sweet_xml is required for role based authentication")
+  def xpath(parent, spec, subspec) do
+    xml_module().xpath(parent, spec, subspec)
+  rescue
+    _ in UndefinedFunctionError ->
+      raise "Dependency sweet_xml is required for role based authentication"
   end
+
+  def sigil_x(path, modifiers) do
+    xml_module().sigil_x(path, modifiers)
+  rescue
+    _ in UndefinedFunctionError ->
+      raise "Dependency sweet_xml is required for role based authentication"
+  end
+
+  defp xml_module, do: Application.get_env(:ex_aws_sts, :xml_module, SweetXml)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -50,9 +50,9 @@ defmodule ExAws.STS.Mixfile do
       {:briefly, ">= 0.0.3", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:hackney, ">= 0.0.0", only: [:dev, :test]},
+      {:sweet_xml, ">= 0.0.0", only: [:dev, :test]},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
-      ex_aws(),
-      sweet_xml()
+      ex_aws()
     ]
     |> Enum.reject(&is_nil/1)
   end
@@ -71,13 +71,6 @@ defmodule ExAws.STS.Mixfile do
     case System.get_env("AWS") do
       "LOCAL" -> {:ex_aws, path: "../ex_aws"}
       _ -> {:ex_aws, "~> 2.2"}
-    end
-  end
-
-  defp sweet_xml do
-    case System.get_env("SWEET_XML") do
-      "DISABLED" -> nil
-      _ -> {:sweet_xml, ">= 0.0.0", only: [:dev, :test]}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,6 @@ defmodule ExAws.STS.Mixfile do
       {:jason, ">= 0.0.0", only: [:dev, :test]},
       ex_aws()
     ]
-    |> Enum.reject(&is_nil/1)
   end
 
   defp docs do

--- a/mix.exs
+++ b/mix.exs
@@ -50,10 +50,11 @@ defmodule ExAws.STS.Mixfile do
       {:briefly, ">= 0.0.3", only: :test},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:hackney, ">= 0.0.0", only: [:dev, :test]},
-      {:sweet_xml, ">= 0.0.0", only: [:dev, :test]},
       {:jason, ">= 0.0.0", only: [:dev, :test]},
-      ex_aws()
+      ex_aws(),
+      sweet_xml()
     ]
+    |> Enum.reject(&is_nil/1)
   end
 
   defp docs do
@@ -70,6 +71,13 @@ defmodule ExAws.STS.Mixfile do
     case System.get_env("AWS") do
       "LOCAL" -> {:ex_aws, path: "../ex_aws"}
       _ -> {:ex_aws, "~> 2.2"}
+    end
+  end
+
+  defp sweet_xml do
+    case System.get_env("SWEET_XML") do
+      "DISABLED" -> nil
+      _ -> {:sweet_xml, ">= 0.0.0", only: [:dev, :test]}
     end
   end
 end

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -31,7 +31,7 @@ defmodule ExAws.STS.ParsersTest do
 
   if System.get_env("SWEET_XML") == "DISABLED" do
     for {action, arity} <- @actions do
-      test "raises missing sweet xml error for `:#{action}`" do
+      test "raises missing sweet_xml error for `:#{action}`" do
         assert_raise RuntimeError,
                     "Dependency sweet_xml is required for role based authentication",
                     fn -> parse_mock_response(unquote(action), unquote(arity)) end

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -29,24 +29,32 @@ defmodule ExAws.STS.ParsersTest do
     get_federation_token: 2
   ]
 
-  if System.get_env("SWEET_XML") == "DISABLED" do
+  # Build tests for all actions and verifies that mock responses were parsed
+  for {action, arity} <- @actions do
+    @tag action: action
+    test "parses `:#{action}` using mock response" do
+      assert {:ok, %{body: body}} = parse_mock_response(unquote(action), unquote(arity))
+
+      for {_, value} <- body do
+        assert value && value != "", "did not parse value for response"
+      end
+    end
+  end
+
+  describe "when sweet_xml is not installed" do
+    setup do
+      Application.put_env(:ex_aws_sts, :xml_module, MissingSweetXml)
+
+      on_exit(fn ->
+        Application.delete_env(:ex_aws_sts, :xml_module)
+      end)
+    end
+
     for {action, arity} <- @actions do
       test "raises missing sweet_xml error for `:#{action}`" do
         assert_raise RuntimeError,
                      "Dependency sweet_xml is required for role based authentication",
                      fn -> parse_mock_response(unquote(action), unquote(arity)) end
-      end
-    end
-  else
-    # Build tests for all actions and verifies that mock responses were parsed
-    for {action, arity} <- @actions do
-      @tag action: action
-      test "parses `:#{action}` using mock response" do
-        assert {:ok, %{body: body}} = parse_mock_response(unquote(action), unquote(arity))
-
-        for {_, value} <- body do
-          assert value && value != "", "did not parse value for response"
-        end
       end
     end
   end

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -29,14 +29,24 @@ defmodule ExAws.STS.ParsersTest do
     get_federation_token: 2
   ]
 
-  # Build tests for all actions and verifies that mock responses were parsed
-  for {action, arity} <- @actions do
-    @tag action: action
-    test "parses `:#{action}` using mock response" do
-      assert {:ok, %{body: body}} = parse_mock_response(unquote(action), unquote(arity))
+  if System.get_env("SWEET_XML") == "DISABLED" do
+    for {action, arity} <- @actions do
+      test "raises missing sweet xml error for `:#{action}`" do
+        assert_raise RuntimeError,
+                    "Dependency sweet_xml is required for role based authentication",
+                    fn -> parse_mock_response(unquote(action), unquote(arity)) end
+      end
+    end
+  else
+    # Build tests for all actions and verifies that mock responses were parsed
+    for {action, arity} <- @actions do
+      @tag action: action
+      test "parses `:#{action}` using mock response" do
+        assert {:ok, %{body: body}} = parse_mock_response(unquote(action), unquote(arity))
 
-      for {_, value} <- body do
-        assert value && value != "", "did not parse value for response"
+        for {_, value} <- body do
+          assert value && value != "", "did not parse value for response"
+        end
       end
     end
   end

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -1,5 +1,5 @@
 defmodule ExAws.STS.ParsersTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias ExAws.STS.Parsers
 

--- a/test/lib/parsers_test.exs
+++ b/test/lib/parsers_test.exs
@@ -33,8 +33,8 @@ defmodule ExAws.STS.ParsersTest do
     for {action, arity} <- @actions do
       test "raises missing sweet_xml error for `:#{action}`" do
         assert_raise RuntimeError,
-                    "Dependency sweet_xml is required for role based authentication",
-                    fn -> parse_mock_response(unquote(action), unquote(arity)) end
+                     "Dependency sweet_xml is required for role based authentication",
+                     fn -> parse_mock_response(unquote(action), unquote(arity)) end
       end
     end
   else


### PR DESCRIPTION
Fixes https://github.com/ex-aws/ex_aws_sts/issues/37

Note: Since I unindented an entire module, I suggest reviewing this PR with the "Hide whitespace" option enabled to make reviewing easier:

<img width="390" alt="Screen Shot 2023-09-12 at 8 22 13 PM" src="https://github.com/ex-aws/ex_aws_sts/assets/830208/8cb2ec9c-091c-4eb8-84f8-50e17117c6bb">