### PR TITLE
feat: add a Pod Identity adapter

### DIFF
--- a/lib/ex_aws/sts/auth_cache/assume_role_pod_identity_adapter.ex
+++ b/lib/ex_aws/sts/auth_cache/assume_role_pod_identity_adapter.ex
@@ -1,0 +1,45 @@
+defmodule ExAws.STS.AuthCache.AssumeRolePodIdentityAdapter do
+  @moduledoc """
+  Provides a custom Adapter that intercepts ExAWS configuration
+  which uses Pod Identity Tokens for authentication.
+  """
+
+  @behaviour ExAws.Config.AuthCache.AuthConfigAdapter
+
+  @impl true
+  def adapt_auth_config(config, _profile, _expiration) do
+    http_config = ExAws.Config.http_config(:sts)
+
+    case http_config.http_client.request(:get, container_credentials_full_uri(config), "", [
+           {"Authorization", container_authorization_token(config)}
+         ]) do
+      {:ok, %{body: body}} ->
+        values = http_config.json_codec.decode!(body)
+
+        %{
+          access_key_id: values["AccessKeyId"],
+          secret_access_key: values["SecretAccessKey"],
+          security_token: values["Token"],
+          expiration: values["Expiration"]
+        }
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp container_credentials_full_uri(config) do
+    config[:container_credentials_uri] || System.get_env("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+  end
+
+  defp container_authorization_token(config) do
+    config
+    |> container_authorization_token_file()
+    |> File.read!()
+  end
+
+  defp container_authorization_token_file(config) do
+    config[:container_authorization_token_file] ||
+      System.get_env("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE")
+  end
+end


### PR DESCRIPTION
I needed to use the [Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) feature so I wrote a quick auth adapter that _seems_ to work. I'm going to get this rolled out in our staging environment and do some more extensive testing soon. I wanted to go ahead and contribute the code back in case anyone else is also going down this path.

Let me know if there are any changes that need to be made.